### PR TITLE
feat: renamed gem to `fluent-plugin-influxdb-v2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ commands:
       - restore_cache:
           name: Restoring Gem Cache
           keys:
-            - &cache-key gem-cache-{{ checksum "influxdb-plugin-fluent.gemspec" }}-<< parameters.ruby-image >>
-            - gem-cache-{{ checksum "influxdb-plugin-fluent.gemspec" }}
+            - &cache-key gem-cache-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}-<< parameters.ruby-image >>
+            - gem-cache-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}
             - gem-cache-
       - run:
           name: Install dependencies
@@ -111,11 +111,11 @@ jobs:
       - run:
           name: Build a Gem bundle
           command: |
-            gem build influxdb-plugin-fluent.gemspec
+            gem build fluent-plugin-influxdb-v2.gemspec
       - run:
           name: Deploy pre-release into https://rubygems.org
           command: |
-            gem push influxdb-plugin-fluent-*.pre.$CIRCLE_BUILD_NUM.gem
+            gem push fluent-plugin-influxdb-v2-*.pre.$CIRCLE_BUILD_NUM.gem
 workflows:
   version: 2
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@
 /Gemfile.lock
 /test/reports/
 .rakeTasks
-**/influxdb-plugin-fluent*.gem
+**/fluent-plugin-influxdb-v2*.gem
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.5.0 [2020-07-17]
 
+1. [#12](https://github.com/influxdata/influxdb-plugin-fluent/pull/12): Renamed gem to `fluent-plugin-influxdb-v2`
+
 ### Dependencies
 1. [#11](https://github.com/influxdata/influxdb-plugin-fluent/pull/11): Upgrade InfluxDB client to 1.6.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in influxdb-plugin-fluent.gemspec
+# Specify your gem's dependencies in fluent-plugin-influxdb-v2.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/influxdata/influxdb-plugin-fluent.svg?style=svg)](https://circleci.com/gh/influxdata/influxdb-plugin-fluent)
 [![codecov](https://codecov.io/gh/influxdata/influxdb-plugin-fluent/branch/master/graph/badge.svg)](https://codecov.io/gh/influxdata/influxdb-plugin-fluent)
-[![Gem Version](https://badge.fury.io/rb/influxdb-plugin-fluent.svg)](https://badge.fury.io/rb/influxdb-plugin-fluent)
+[![Gem Version](https://badge.fury.io/rb/fluent-plugin-influxdb-v2.svg)](https://badge.fury.io/rb/fluent-plugin-influxdb-v2)
 [![License](https://img.shields.io/github/license/influxdata/influxdb-plugin-fluent.svg)](https://github.com/influxdata/influxdb-plugin-fluent/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues-raw/influxdata/influxdb-plugin-fluent.svg)](https://github.com/influxdata/influxdb-plugin-fluent/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/influxdata/influxdb-plugin-fluent.svg)](https://github.com/influxdata/influxdb-plugin-fluent/pulls)
@@ -16,10 +16,10 @@ This repository contains the reference Fluentd plugin for the InfluxDB 2.0.
 
 ### Gems
 
-The plugin is bundled as a gem and is hosted on [Rubygems](https://rubygems.org/gems/influxdb-plugin-fluent).  You can install the gem as follows:
+The plugin is bundled as a gem and is hosted on [Rubygems](https://rubygems.org/gems/fluent-plugin-influxdb-v2).  You can install the gem as follows:
 
 ```
-fluent-gem install influxdb-plugin-fluent -v 1.5.0
+fluent-gem install fluent-plugin-influxdb-v2 -v 1.5.0
 ```
 
 ## Plugins

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,7 +69,7 @@ FROM fluent/fluentd:edge-debian
 
 USER root
 
-RUN fluent-gem install influxdb-plugin-fluent
+RUN fluent-gem install fluent-plugin-influxdb-v2
 
 COPY ./fluent.conf /fluentd/etc/
 COPY entrypoint.sh /bin/

--- a/examples/fluentd/Dockerfile
+++ b/examples/fluentd/Dockerfile
@@ -2,9 +2,9 @@ FROM fluent/fluentd:edge-debian
 
 USER root
 
-COPY ./influxdb-plugin-fluent.gem /fluentd/plugins
+COPY ./fluent-plugin-influxdb-v2.gem /fluentd/plugins
 
-RUN fluent-gem install /fluentd/plugins/influxdb-plugin-fluent.gem
+RUN fluent-gem install /fluentd/plugins/fluent-plugin-influxdb-v2.gem
 
 COPY ./fluent.conf /fluentd/etc/
 COPY entrypoint.sh /bin/

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -59,8 +59,8 @@ docker run \
 # Build actual version of output plugin
 #
 cd "${SCRIPT_PATH}"/../
-docker run --rm -v "${SCRIPT_PATH}/../":/usr/src/app -w /usr/src/app ruby:2.6 gem build influxdb-plugin-fluent.gemspec \
-  -o ./examples/fluentd/influxdb-plugin-fluent.gem
+docker run --rm -v "${SCRIPT_PATH}/../":/usr/src/app -w /usr/src/app ruby:2.6 gem build fluent-plugin-influxdb-v2.gemspec \
+  -o ./examples/fluentd/fluent-plugin-influxdb-v2.gem
 
 #
 # Build fluentd Docker image with output plugin

--- a/fluent-plugin-influxdb-v2.gemspec
+++ b/fluent-plugin-influxdb-v2.gemspec
@@ -23,7 +23,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fluent/plugin/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'influxdb-plugin-fluent'
+  spec.name          = 'fluent-plugin-influxdb-v2'
   spec.version       = if ENV['CIRCLE_BUILD_NUM']
                          "#{InfluxDB2::Plugin::Fluent::VERSION}-#{ENV['CIRCLE_BUILD_NUM']}"
                        else
@@ -33,8 +33,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['jakub.bednar@gmail.com']
 
   spec.summary       = 'InfluxDB 2 output plugin for Fluentd'
-  spec.description   = 'The gem is renamed to fluent-plugin-influxdb-v2. '\
-'A buffered output plugin for Fluentd and InfluxDB 2'
+  spec.description   = 'A buffered output plugin for Fluentd and InfluxDB 2'
   spec.homepage      = 'https://github.com/influxdata/influxdb-plugin-fluent'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
1. the plugin name should be: `fluent-plugin-xyz`
1. new gem name: **fluent-plugin-influxdb-v2**

> I wrote a new plugin. How to add this plugin to plugin page?
>
> Our script updates a plugin page periodically and this script collects the information of fluent-plugin-xxx gems. If you want to add your gem on plugin page, release it as fluent-plugin-xxx, not fluentd-plugin-xxx, fluent-xxx-plugin and etc.
> 

https://www.fluentd.org/faqs

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)