### PR TITLE
feat: add possibility to specify the certification verification behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.7.0 [unreleased]
 
+### Features
+1. [#23](https://github.com/influxdata/influxdb-plugin-fluent/pull/23): Added possibility to specify the certification verification behaviour
+
 ### CI
-1. [#19](https://github.com/influxdata/influxdb-plugin-fluent/pull/19): Updated default docker image to v2.0.3
+1. [#21](https://github.com/influxdata/influxdb-plugin-fluent/pull/21): Updated default docker image to v2.0.4
 
 ## 1.6.0 [2020-10-02]
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Store Fluentd event to InfluxDB 2 database.
 | url | InfluxDB URL to connect to (ex. https://localhost:8086). | String | https://localhost:8086 |
 | token | Access Token used for authenticating/authorizing the InfluxDB request sent by client. | String | |
 | use_ssl | Turn on/off SSL for HTTP communication. | bool | true |
+| verify_mode | Sets the flags for the certification verification at beginning of SSL/TLS session. | `"#{OpenSSL::SSL::VERIFY_NONE}"` or `"#{OpenSSL::SSL::VERIFY_PEER}"` | none |
 | bucket | Specifies the destination bucket for writes. | String | |
 | org | Specifies the destination organization for writes. | String | |
 | measurement | The name of the measurement. If not specified, Fluentd's tag is used. | String | nil |
@@ -75,6 +76,9 @@ Store Fluentd event to InfluxDB 2 database.
     token                   my-token
     # Turn on/off SSL for HTTP communication.
     use_ssl                 true
+    # Sets the flags for the certification verification at beginning of SSL/TLS session.
+    # For more info see - https://docs.ruby-lang.org/en/3.0.0/Net/HTTP.html#verify_mode.
+    verify_mode             "#{OpenSSL::SSL::VERIFY_NONE}"
 
     # Specifies the destination bucket for writes.
     bucket                  my-bucket

--- a/fluent-plugin-influxdb-v2.gemspec
+++ b/fluent-plugin-influxdb-v2.gemspec
@@ -47,7 +47,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'fluentd', '~> 1.8'
-  spec.add_runtime_dependency 'influxdb-client', '1.8.0'
+  # Temporary depends to prerelease version - will be change to 1.12.0 after release the client
+  spec.add_runtime_dependency 'influxdb-client', '1.12.0.pre.1894'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'codecov', '~> 0.2.8'

--- a/fluent-plugin-influxdb-v2.gemspec
+++ b/fluent-plugin-influxdb-v2.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'influxdb-client', '1.12.0.pre.1894'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'codecov', '~> 0.2.8'
+  spec.add_development_dependency 'codecov', '~> 0.1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/lib/fluent/plugin/out_influxdb2.rb
+++ b/lib/fluent/plugin/out_influxdb2.rb
@@ -38,6 +38,10 @@ class InfluxDBOutput < Fluent::Plugin::Output
   config_param :use_ssl, :bool, default: true
   desc 'Turn on/off SSL for HTTP communication.'
 
+  config_param :verify_mode, :integer, default: nil
+  desc 'Sets the flags for the certification verification at beginning of SSL/TLS session. ' \
+      'For more info see - https://docs.ruby-lang.org/en/3.0.0/Net/HTTP.html#verify_mode.'
+
   config_param :bucket, :string
   desc 'Specifies the destination bucket for writes.'
 
@@ -97,8 +101,9 @@ class InfluxDBOutput < Fluent::Plugin::Output
   def start
     super
     log.info  "Connecting to InfluxDB: url: #{@url}, bucket: #{@bucket}, org: #{@org}, precision = #{@precision}, " \
-              "use_ssl = #{@use_ssl}"
-    @client = InfluxDB2::Client.new(@url, @token, bucket: @bucket, org: @org, precision: @precision, use_ssl: @use_ssl)
+              "use_ssl = #{@use_ssl}, verify_mode = #{@verify_mode}"
+    @client = InfluxDB2::Client.new(@url, @token, bucket: @bucket, org: @org, precision: @precision, use_ssl: @use_ssl,
+                                                  verify_mode: @verify_mode)
     @write_api = @client.create_write_api
   end
 

--- a/test/influxdb/plugin/output_test.rb
+++ b/test/influxdb/plugin/output_test.rb
@@ -117,6 +117,41 @@ class InfluxDBOutputTest < Minitest::Test
     assert_equal '\'use_ssl\' parameter is required but nil is specified', error.message
   end
 
+  def test_verify_mode_default
+    driver = create_driver(%(
+        @type influxdb2
+        bucket my-bucket
+        org my-org
+        token my-token
+    ))
+
+    assert_nil driver.instance.verify_mode
+  end
+
+  def test_verify_mode_none
+    driver = create_driver(%(
+        @type influxdb2
+        bucket my-bucket
+        org my-org
+        token my-token
+        verify_mode "#{OpenSSL::SSL::VERIFY_NONE}"
+    ))
+
+    assert_equal OpenSSL::SSL::VERIFY_NONE, driver.instance.verify_mode
+  end
+
+  def test_verify_mode_peer
+    driver = create_driver(%(
+        @type influxdb2
+        bucket my-bucket
+        org my-org
+        token my-token
+        verify_mode "#{OpenSSL::SSL::VERIFY_PEER}"
+    ))
+
+    assert_equal OpenSSL::SSL::VERIFY_PEER, driver.instance.verify_mode
+  end
+
   def test_bucket_parameter
     error = assert_raises Fluent::ConfigError do
       create_driver(%(


### PR DESCRIPTION
Closes #22

## Proposed Changes

Added the new option to customise certification verification behaviour:

| Option | Description | Type | Default |
|---|---|---|---|
| verify_mode | Sets the flags for the certification verification at beginning of SSL/TLS session. | `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER` | none |


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
