### PR TITLE
chore(ci): use latest tag for InfluxDB 2, use correct image for InfluxDB 2 nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,10 @@ jobs:
         default: &default-ruby-image "circleci/ruby:2.6-stretch"
       influxdb-image:
         type: string
-        default: &default-influxdb-image "influxdb:v2.0.4"
+        default: &default-influxdb-image "influxdb:latest"
     docker:
       - image: << parameters.ruby-image >>
-      - image: &influx-image quay.io/influxdb/<< parameters.influxdb-image >>
+      - image: &influx-image << parameters.influxdb-image >>
         environment:
           INFLUXD_HTTP_BIND_ADDRESS: :8086
     steps:
@@ -124,7 +124,7 @@ workflows:
           name: ruby-2.6
       - tests-ruby:
           name: ruby-2.6-nightly
-          influxdb-image: "influxdb2:nightly"
+          influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-ruby:
           name: ruby-2.5
           ruby-image: "circleci/ruby:2.5-stretch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#23](https://github.com/influxdata/influxdb-plugin-fluent/pull/23): Added possibility to specify the certification verification behaviour
 
 ### CI
-1. [#21](https://github.com/influxdata/influxdb-plugin-fluent/pull/21): Updated default docker image to v2.0.4
+1. [#24](https://github.com/influxdata/influxdb-plugin-fluent/pull/24): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
 
 ## 1.6.0 [2020-10-02]
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ docker run \
        --name influxdb_v2 \
        --network influx_network \
        --publish 8086:8086 \
-       quay.io/influxdb/influxdb:v2.0.4
+       influxdb:latest
 ```
 
 Create default organization, user and bucket:

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -49,7 +49,7 @@ docker run \
        --name influxdb_v2 \
        --network influx_network \
        --publish 8086:8086 \
-       quay.io/influxdb/influxdb:v2.0.4
+       influxdb:latest
 
 #
 # Post onBoarding request to InfluxDB 2


### PR DESCRIPTION
## Proposed Changes

- use `influxdb:latest` for stable InfluxDB 2
- use `quay.io/influxdb/influxdb:nightly` for nightly InfluxDB 2

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
