### PR TITLE
feat: add placeholder support for bucket & measurement fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.8.0 [unreleased]
 
+### Features
+1. [#26](https://github.com/influxdata/influxdb-plugin-fluent/pull/26): Added placeholder support for bucket & measurement fields
+
 ## 1.7.0 [2021-03-05]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.8.0 [unreleased]
 
 ### Features
-1. [#26](https://github.com/influxdata/influxdb-plugin-fluent/pull/26): Added placeholder support for bucket & measurement fields
+1. [#26](https://github.com/influxdata/influxdb-plugin-fluent/pull/26): Add placeholder support for bucket & measurement fields
 
 ## 1.7.0 [2021-03-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 ## 1.7.0 [2021-03-05]
 
 ### Features
-1. [#23](https://github.com/influxdata/influxdb-plugin-fluent/pull/23): Added possibility to specify the certification verification behaviour
+1. [#23](https://github.com/influxdata/influxdb-plugin-fluent/pull/23): Add possibility to specify the certification verification behaviour
 
 ### CI
-1. [#24](https://github.com/influxdata/influxdb-plugin-fluent/pull/24): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
+1. [#24](https://github.com/influxdata/influxdb-plugin-fluent/pull/24): Updat stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
 
 ## 1.6.0 [2020-10-02]
 
@@ -21,7 +21,7 @@
 
 ## 1.5.0 [2020-07-17]
 
-1. [#12](https://github.com/influxdata/influxdb-plugin-fluent/pull/12): Renamed gem to `fluent-plugin-influxdb-v2`
+1. [#12](https://github.com/influxdata/influxdb-plugin-fluent/pull/12): Rename gem to `fluent-plugin-influxdb-v2`
 
 ### Dependencies
 1. [#11](https://github.com/influxdata/influxdb-plugin-fluent/pull/11): Upgrade InfluxDB client to 1.6.0
@@ -29,7 +29,7 @@
 ## 1.4.0 [2020-06-19]
 
 ### Features
-1. [#8](https://github.com/influxdata/influxdb-plugin-fluent/pull/8): Added support for nested fields
+1. [#8](https://github.com/influxdata/influxdb-plugin-fluent/pull/8): Add support for nested fields
 
 ### Dependencies
 1. [#9](https://github.com/influxdata/influxdb-plugin-fluent/pull/9): Upgrade InfluxDB client to 1.5.0

--- a/lib/fluent/plugin/out_influxdb2.rb
+++ b/lib/fluent/plugin/out_influxdb2.rb
@@ -149,14 +149,12 @@ class InfluxDBOutput < Fluent::Plugin::Output
 
   def expand_placeholders(chunk)
     bucket = extract_placeholders(@bucket, chunk)
-
-    if @measurement
-      measurement = extract_placeholders(@measurement, chunk)
-    else
-      measurement = chunk.metadata.tag
-    end
-
-    return bucket, measurement
+    measurement = if @measurement
+                    extract_placeholders(@measurement, chunk)
+                  else
+                    chunk.metadata.tag
+                  end
+    [bucket, measurement]
   end
 
   def _parse_field(key, value, point)

--- a/lib/fluent/plugin/out_influxdb2.rb
+++ b/lib/fluent/plugin/out_influxdb2.rb
@@ -119,7 +119,7 @@ class InfluxDBOutput < Fluent::Plugin::Output
   def write(chunk)
     points = []
     tag = chunk.metadata.tag
-    measurement = @measurement || tag
+    bucket, measurement = expand_placeholders(chunk)
     chunk.msgpack_each do |time, record|
       if time.is_a?(Integer)
         time_formatted = time
@@ -141,11 +141,23 @@ class InfluxDBOutput < Fluent::Plugin::Output
       point.time(time_formatted, @precision)
       points << point
     end
-    @write_api.write(data: points)
+    @write_api.write(data: points, bucket: bucket)
     log.debug "Written points: #{points}"
   end
 
   private
+
+  def expand_placeholders(chunk)
+    bucket = extract_placeholders(@bucket, chunk)
+
+    if @measurement
+      measurement = extract_placeholders(@measurement, chunk)
+    else
+      measurement = chunk.metadata.tag
+    end
+
+    return bucket, measurement
+  end
 
   def _parse_field(key, value, point)
     if @tag_keys.include?(key)


### PR DESCRIPTION
## Proposed Changes

Add placeholder support for bucket & measurement fields.

[Placeholder](https://docs.fluentd.org/configuration/buffer-section#placeholders) is a very useful feature provided by fluentd, we can leverage this feature to dynamically specify measurement & bucket parameters.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
