### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
     parameters:
       ruby-image:
         type: string
-        default: &default-ruby-image "circleci/ruby:2.6-stretch"
+        default: &default-ruby-image "cimg/ruby:2.6"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -119,7 +119,7 @@ workflows:
     jobs:
       - tests-ruby:
           name: ruby-2.7
-          ruby-image: "circleci/ruby:2.7-buster"
+          ruby-image: "cimg/ruby:2.7"
       - tests-ruby:
           name: ruby-2.6
       - tests-ruby:
@@ -127,10 +127,10 @@ workflows:
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-ruby:
           name: ruby-2.5
-          ruby-image: "circleci/ruby:2.5-stretch"
+          ruby-image: "cimg/ruby:2.5"
       - tests-ruby:
           name: ruby-2.4
-          ruby-image: "circleci/ruby:2.4-stretch"
+          ruby-image: "cimg/ruby:2.4"
       - deploy-preview:
           requires:
             - ruby-2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ commands:
       - restore_cache:
           name: Restoring Gem Cache
           keys:
-            - &cache-key gem-cache-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}-<< parameters.ruby-image >>
-            - gem-cache-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}
-            - gem-cache-
+            - &cache-key gem-cache-v2-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}-<< parameters.ruby-image >>
+            - gem-cache-v2-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}
+            - gem-cache-v2-
       - run:
           name: Install dependencies
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.9.0 [unreleased]
 
+### CI
+1. [#27](https://github.com/influxdata/influxdb-plugin-fluent/pull/27): Switch to next-gen CircleCI's convenience images
+
 ## 1.8.0 [2021-08-20]
 
 ### Features


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
