### PR TITLE
feat: field value for time_key can be formatted date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ commands:
       - restore_cache:
           name: Restoring Gem Cache
           keys:
-            - &cache-key gem-cache-v2-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}-<< parameters.ruby-image >>
-            - gem-cache-v2-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}
-            - gem-cache-v2-
+            - &cache-key gem-cache-v3-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}-<< parameters.ruby-image >>
+            - gem-cache-v3-{{ checksum "fluent-plugin-influxdb-v2.gemspec" }}
+            - gem-cache-v3-
       - run:
           name: Install dependencies
           command: |
@@ -120,6 +120,9 @@ workflows:
       - tests-ruby:
           name: ruby-2.7
           ruby-image: "cimg/ruby:2.7"
+      - tests-ruby:
+          name: ruby-3.0
+          ruby-image: "cimg/ruby:3.0"
       - tests-ruby:
           name: ruby-2.6
       - tests-ruby:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.9.0 [unreleased]
 
+### Dependencies
+1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Update dependencies:
+    - influxdb-client to 2.1.0
+
 ### CI
 1. [#27](https://github.com/influxdata/influxdb-plugin-fluent/pull/27): Switch to next-gen CircleCI's convenience images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### CI
 1. [#27](https://github.com/influxdata/influxdb-plugin-fluent/pull/27): Switch to next-gen CircleCI's convenience images
+1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Add Ruby 3.0 into CI
 
 ## 1.8.0 [2021-08-20]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.9.0 [unreleased]
 
+1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Field value for `time_key` can be formatted date (`2021-11-05 09:15:49.487727165 +0000`, `2021-11-05T10:04:43.617216Z`)
+
+
 ### Dependencies
 1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Update dependencies:
     - influxdb-client to 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.9.0 [unreleased]
 
+### Features
 1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Field value for `time_key` can be formatted date (`2021-11-05 09:15:49.487727165 +0000`, `2021-11-05T10:04:43.617216Z`)
-
 
 ### Dependencies
 1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Update dependencies:

--- a/fluent-plugin-influxdb-v2.gemspec
+++ b/fluent-plugin-influxdb-v2.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'fluentd', '~> 1.8'
-  spec.add_runtime_dependency 'influxdb-client', '1.12.0'
+  spec.add_runtime_dependency 'influxdb-client', '2.1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'codecov', '~> 0.1.16'

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,0 +1,26 @@
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+inherit_from: ../.rubocop.yml
+Metrics/ClassLength:
+  Enabled: false
+


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-plugin-fluent/issues/29

## Proposed Changes

1. The field value for `time_key` can be formatted date - `2021-11-05 09:15:49.487727165 +0000`, `2021-11-05T10:04:43.617216Z`.
1. Updated client to `v2.1.0`
1. Added Ruby 3.0 into CI

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
