### PR TITLE
feat: add possibility to ingest LineProtocol from Fluetd's event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Field value for `time_key` can be formatted date (`2021-11-05 09:15:49.487727165 +0000`, `2021-11-05T10:04:43.617216Z`)
+1. [#31](https://github.com/influxdata/influxdb-plugin-fluent/pull/31): Add possibility to use LineProtocol from Fluetd's record.
 
 ### Dependencies
 1. [#30](https://github.com/influxdata/influxdb-plugin-fluent/pull/30): Update dependencies:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Store Fluentd event to InfluxDB 2 database.
 | field_cast_to_float | Turn on/off auto casting Integer value to Float. Helper to avoid mismatch error: 'series type mismatch: already Integer but got Float'. | bool | false |
 | time_precision | The time precision of timestamp. You should specify either second (s), millisecond (ms), microsecond (us), or nanosecond (ns). | String | ns |
 | time_key | A name of the record key that used as a 'timestamp' instead of event timestamp. If a record key doesn't exists or hasn't value then is used event timestamp. | String | nil |
+| line_protocol_key | A name of the record key that contains [LineProtocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/). The value of this key is used for ingesting data into InfluxDB. If a record key doesn't exists or hasn't value then is used event timestamp. | String | nil |
 
 ##### Minimal configuration
 


### PR DESCRIPTION
Closes #25

## Proposed Changes

Added possibility to use LineProtocol from Fluetd's record:

```yaml
<match influxdb2.**>
      @type influxdb2
      token my-token
      bucket my-bucket
      org my-org
      line_protocol_key lp_key
</match>
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
