### PR TITLE
refactor: Deprecate and remove semantic-pull-requests, insert influxdata replacement reusable workflow solution.

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,0 @@
-# docs: https://github.com/probot/semantic-pull-requests#configuration
-# Always validate the PR title AND all the commits
-titleAndCommits: true

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,15 @@
+---
+name: "Semantic PR and Commit Messages"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - master
+
+jobs:
+  semantic:
+    uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
+    with:
+      CHECK_PR_TITLE_OR_ONE_COMMIT: true
+

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -12,4 +12,3 @@ jobs:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
     with:
       CHECK_PR_TITLE_OR_ONE_COMMIT: true
-


### PR DESCRIPTION
The github application "semantic-pull-requests" uses a very old node version and presents security vulnerabilities. The repo manager has not addressed the issue and has become nonresponsive. Influxdata has its own solution based in github reusable workflows.  

**This change is org-wide to address security vulnerabilites in semantic-pull-requests, by removing it.**

Closes #

## Proposed Changes
Remove semantic-pull-requests.  Add https://github.com/influxdata/validate-semantic-github-messages

_Briefly describe your proposed changes:_
'nuff said

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [n/a] CHANGELOG.md updated
- [n/a] Rebased/mergeable
- [n/a] A test has been added if appropriate
- [n/a] Tests pass
- [yes] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [n/a] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)