### PR TITLE
chore(ci): add Ruby 3.1 to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ workflows:
           name: ruby-3.0
           ruby-image: "cimg/ruby:3.0"
       - tests-ruby:
+          name: ruby-3.1
+          ruby-image: "cimg/ruby:3.1"
+      - tests-ruby:
           name: ruby-2.6
       - tests-ruby:
           name: ruby-2.6-nightly
@@ -147,6 +150,8 @@ workflows:
           ruby-image: "cimg/ruby:2.4"
       - deploy-preview:
           requires:
+            - ruby-3.0
+            - ruby-3.1
             - ruby-2.7
             - ruby-2.6
             - ruby-2.6-nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
     - influxdb-client to 2.6.0
 
 ### CI
+1. [#39](https://github.com/influxdata/influxdb-plugin-fluent/pull/39): Add Ruby 3.1 into CI
+
+### CI
 1. [#32](https://github.com/influxdata/influxdb-plugin-fluent/pull/32): Use new Codecov uploader for reporting code coverage
 
 ## 1.9.0 [2021-11-26]


### PR DESCRIPTION
## Proposed Changes

Add Ruby 3.1 to CI build.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
